### PR TITLE
refactor: refactor WebRTC starting conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current version: 0.17.1
 -   [FAQ](#faq)
     -   [How can I add CLI arguments to my `spyglass.conf`?](#how-can-i-add-cli-arguments-to-my-spyglassconf)
     -   [How to use resolutions higher than maximum resolution?](#how-to-use-resolutions-higher-than-maximum-resolution)
-    -   [Why is the CPU load on my Pi5 so high?](#why-is-the-cpu-load-on-my-pi5-so-high)
+    -   [Why is there no WebRTC on my Pi5?](#why-is-there-no-webrtc-on-my-pi5)
     -   [How can I rotate the image of my stream?](#how-can-i-rotate-the-image-of-my-stream)
     -   [How to apply tuning filter?](#how-to-apply-tuning-filter)
     -   [How to use the WebRTC endpoint?](#how-to-use-the-webrtc-endpoint)
@@ -128,8 +128,8 @@ On startup the following arguments are supported:
 | `-tf`, `--tuning_filter`       | Set a tuning filter file name.                                                                                                     |              |
 | `-tfd`, `--tuning_filter_dir`  | Set the directory to look for tuning filters.                                                                                      |              |
 | `-n`, `--camera_num`           | Camera number to be used. All cameras with their number can be shown with `libcamera-hello`.                                       | `0`          |
-| `-sw`, `--use_sw_jpg_encoding` | Use software encoding for JPEG and MJPG (recommended on Pi5).                                                                      |              |
-| `--disable_webrtc`             | Disable WebRTC encoding (recommended on Pi5).                                                                                      |              |
+| `-sw`, `--use_sw_encoding`     | Use software encoding for JPEG and MJPG (Disables WebRTC).                                                                         |              |
+| `--force-webrtc`               | Force WebRTC streaming to start.                                                                                                   |              |
 | `--list-controls`              | List all available libcamera controls onto the console. Those can be used with `--controls`.                                       |              |
 
 
@@ -148,21 +148,17 @@ Please note that the maximum recommended resolution is 1920x1080 (16:9).
 
 The absolute maximum resolution is 1920x1920. If you choose a higher resolution spyglass may stop with
 `Maximum supported resolution is 1920x1920`. This is limited by the hardware (HW) encoder of the Pis.\
-You can disable this limit with `--use_sw_jpg_encoding` and `--disable_webrtc`, or the respective config in
-`spyglass.conf`, but it will take way more CPU resources to run the stream and WebRTC won't work anymore.
-Only a Pi5 you don't need to add `--disable_webrtc`, for further information please refer to
-[Pi5 recommendations](#pi5-recommendations).
+You can disable this limit with `--use-sw-encoding`, or the respective config in `spyglass.conf`, but
+it will take way more CPU resources to run the stream and WebRTC won't work anymore.
 
-### Why is the CPU load on my Pi5 so high?
+### Why is there no WebRTC on my Pi5?
 
 The Pi5 is the newest generation of Raspberry Pi SBCs but not all new things come with improvements.
 The Raspberry Pi foundation decided to remove the hardware (HW) encoders from the Pi5.
 This results in overall higher CPU usage on a Pi5 compared to previous generations.
 
-The following sections should only be followed on a Pi5.\
-WebRTC is also a big toll on your CPU. Therefore, you should use `--disable_webrtc`.\
-To reduce the CPU usage further you should add `--use_sw_jpg_encoding` to make sure to use the optimized software (SW)
-encoder, instead of the HW encoder falling back to an unoptimized SW encoder.
+WebRTC is a big toll on your CPU. Therefore we disabled it by default, you can use `--force-webrtc` to enable it, but
+keep an eye on your CPU usage if you run software with critical timings like Klipper.\
 
 ### How can I rotate the image of my stream?
 

--- a/resources/spyglass.conf
+++ b/resources/spyglass.conf
@@ -41,8 +41,8 @@ SNAPSHOT_URL="/snapshot"
 #### WebRTC URL (STRING)[default: /webrtc]
 WEBRTC_URL="/webrtc"
 
-#### Disable WebRTC (BOOL)[default: false]
-#DISABLE_WEBRTC="true"
+#### Force WebRTC streaming to start (BOOL)[default: false]
+#FORCE_WEBRTC="true"
 
 #### Autofocus behavior (STRING:manual,continuous)[default: continuous]
 AUTO_FOCUS="continuous"

--- a/resources/spyglass.conf
+++ b/resources/spyglass.conf
@@ -35,8 +35,8 @@ SNAPSHOT_URL="/snapshot"
 #### NOTE: use format as shown below to stay MJPG-Streamer URL compatible
 ## SNAPSHOT_URL="/?action=snapshot"
 
-#### Use Software JPG Encoding (BOOL)[default: false]
-#USE_SW_JPG_ENCODING="true"
+#### Use Software Encoding (BOOL)[default: false]
+#USE_SW_ENCODING="true"
 
 #### WebRTC URL (STRING)[default: /webrtc]
 WEBRTC_URL="/webrtc"

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -93,6 +93,8 @@ run_spyglass() {
     fi
 
     use_sw_encoding=""
+    # For backwards compatibility, USE_SW_JPG_ENCODING will be checked here
+    # Might get removed in future
     if [[ "${USE_SW_ENCODING:-false}" == "true" || "${USE_SW_JPG_ENCODING:-false}" == "true" ]]; then
         use_sw_encoding="--use_sw_encoding"
     fi

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -93,16 +93,16 @@ run_spyglass() {
         bind_adress="0.0.0.0"
     fi
 
-    if [[ "${USE_SW_JPG_ENCODING:-false}" == "true" ]]; then
-        use_sw_jpg_encoding="--use_sw_jpg_encoding"
+    if [[ "${USE_SW_ENCODING:-false}" == "true" || "${USE_SW_JPG_ENCODING:-false}" == "true" ]]; then
+        use_sw_encoding="--use_sw_encoding"
     else
         use_sw_jpg_encoding=""
     fi
 
-    if [[ "${DISABLE_WEBRTC:-false}" == "true" ]]; then
-        disable_webrtc="--disable_webrtc"
+    if [[ "${FORCE_WEBRTC:-false}" == "true" ]]; then
+        force_webrtc="--force_webrtc"
     else
-        disable_webrtc=""
+        force_webrtc=""
     fi
 
     "${PY_BIN}" "$(dirname "${BASE_SPY_PATH}")/run.py" \
@@ -113,9 +113,9 @@ run_spyglass() {
     --fps "${FPS:-15}" \
     --stream_url "${STREAM_URL:-/stream}" \
     --snapshot_url "${SNAPSHOT_URL:-/snapshot}" \
-    ${use_sw_jpg_encoding} \
+    ${use_sw_encoding} \
     --webrtc_url "${WEBRTC_URL:-/webrtc}" \
-    ${disable_webrtc} \
+    ${force_webrtc} \
     --autofocus "${AUTO_FOCUS:-continuous}" \
     --lensposition "${FOCAL_DIST:-0.0}" \
     --autofocusspeed "${AF_SPEED:-normal}" \

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -87,22 +87,19 @@ run_spyglass() {
     # ensure default for NO_PROXY
     [[ -n "${NO_PROXY}" ]] || NO_PROXY="true"
 
+    bind_adress="0.0.0.0"
     if [[ "${NO_PROXY}" != "true" ]]; then
         bind_adress="127.0.0.1"
-    else
-        bind_adress="0.0.0.0"
     fi
 
+    use_sw_encoding=""
     if [[ "${USE_SW_ENCODING:-false}" == "true" || "${USE_SW_JPG_ENCODING:-false}" == "true" ]]; then
         use_sw_encoding="--use_sw_encoding"
-    else
-        use_sw_jpg_encoding=""
     fi
 
+    force_webrtc=""
     if [[ "${FORCE_WEBRTC:-false}" == "true" ]]; then
         force_webrtc="--force_webrtc"
-    else
-        force_webrtc=""
     fi
 
     "${PY_BIN}" "$(dirname "${BASE_SPY_PATH}")/run.py" \

--- a/spyglass/__init__.py
+++ b/spyglass/__init__.py
@@ -8,10 +8,9 @@ from picamera2.encoders import _hw_encoder_available
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+WEBRTC_ENABLED = False
 if importlib.util.find_spec("aiortc"):
     WEBRTC_ENABLED = _hw_encoder_available
-else:
-    WEBRTC_ENABLED = False
 
 
 def set_webrtc_enabled(enabled):

--- a/spyglass/__init__.py
+++ b/spyglass/__init__.py
@@ -3,11 +3,13 @@
 import importlib.util
 import logging
 
+from picamera2.encoders import _hw_encoder_available
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 if importlib.util.find_spec("aiortc"):
-    WEBRTC_ENABLED = True
+    WEBRTC_ENABLED = _hw_encoder_available
 else:
     WEBRTC_ENABLED = False
 

--- a/spyglass/camera/camera.py
+++ b/spyglass/camera/camera.py
@@ -105,7 +105,7 @@ class Camera(ABC):
         snapshot_url="/snapshot",
         webrtc_url="/webrtc",
         orientation_exif=0,
-        use_sw_jpg_encoding=False,
+        use_sw_encoding=False,
     ):
         pass
 

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -1,6 +1,7 @@
 import io
 from threading import Condition
 
+from picamera2.encoders import _hw_encoder_available
 from picamera2.outputs import FileOutput
 
 from spyglass import WEBRTC_ENABLED, camera
@@ -16,12 +17,12 @@ class CSI(camera.Camera):
         snapshot_url="/snapshot",
         webrtc_url="/webrtc",
         orientation_exif=0,
-        use_sw_jpg_encoding=False,
+        use_sw_encoding=False,
     ):
-        if use_sw_jpg_encoding:
-            from picamera2.encoders import JpegEncoder as MJPEGEncoder
-        else:
+        if _hw_encoder_available and not use_sw_encoding:
             from picamera2.encoders import MJPEGEncoder
+        else:
+            from picamera2.encoders import JpegEncoder as MJPEGEncoder
 
         class StreamingOutput(io.BufferedIOBase):
             def __init__(self):

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -11,7 +11,7 @@ class USB(camera.Camera):
         snapshot_url="/snapshot",
         webrtc_url="/webrtc",
         orientation_exif=0,
-        use_sw_jpg_encoding=False,
+        use_sw_encoding=False,
     ):
         def get_frame(inner_self):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -41,16 +41,18 @@ def main(args=None):
             print("Available controls:\n" + controls_str)
         return
 
-    use_sw_jpg_encoding = parsed_args.use_sw_jpg_encoding
+    use_sw_encoding = parsed_args.use_sw_encoding
     # Disable max resolution limit for software encoding of JPEG
     width, height = split_resolution(
-        parsed_args.resolution, check_limit=not use_sw_jpg_encoding
+        parsed_args.resolution, check_limit=not use_sw_encoding
     )
     controls = parsed_args.controls
     if parsed_args.controls_string:
         controls += [c.split("=") for c in parsed_args.controls_string.split(",")]
 
-    set_webrtc_enabled(WEBRTC_ENABLED and not parsed_args.disable_webrtc)
+    set_webrtc_enabled(
+        parsed_args.force_webrtc or (WEBRTC_ENABLED and not parsed_args.use_sw_encoding)
+    )
 
     # Has to be imported after WEBRTC_ENABLED got set correctly
     from spyglass.camera import init_camera
@@ -97,7 +99,7 @@ def main(args=None):
             parsed_args.snapshot_url,
             parsed_args.webrtc_url,
             parsed_args.orientation_exif,
-            use_sw_jpg_encoding,
+            use_sw_encoding,
         )
     finally:
         cam.stop()
@@ -217,8 +219,9 @@ def get_parser():
     parser.add_argument(
         "-sw",
         "--use_sw_jpg_encoding",
-        action=argparse.BooleanOptionalAction,
-        help="Use software encoding for JPEG and MJPG (recommended on Pi5)",
+        "--use-sw-encoding",
+        action="store_true",
+        help="Use software encoding for JPEG and MJPG (Disables WebRTC)",
     )
     parser.add_argument(
         "-w",
@@ -228,9 +231,14 @@ def get_parser():
         help="Sets the URL for the WebRTC stream",
     )
     parser.add_argument(
-        "--disable_webrtc",
+        "--force-webrtc",
         action=argparse.BooleanOptionalAction,
-        help="Disables WebRTC encoding (recommended on Pi5)",
+        help="Force WebRTC streaming to start",
+    )
+    parser.add_argument(
+        "--disable_webrtc",
+        action="store_true",
+        help="DEPRECATED",
     )
     parser.add_argument(
         "-af",

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -229,7 +229,7 @@ def get_parser():
     )
     parser.add_argument(
         "--disable_webrtc",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         help="Disables WebRTC encoding (recommended on Pi5)",
     )
     parser.add_argument(

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -217,7 +217,7 @@ def get_parser():
     parser.add_argument(
         "-sw",
         "--use_sw_jpg_encoding",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         help="Use software encoding for JPEG and MJPG (recommended on Pi5)",
     )
     parser.add_argument(

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -218,8 +218,8 @@ def get_parser():
     )
     parser.add_argument(
         "-sw",
-        "--use_sw_jpg_encoding",
         "--use-sw-encoding",
+        "--use_sw_jpg_encoding",
         action="store_true",
         help="Use software encoding for JPEG and MJPG (Disables WebRTC)",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,16 +27,17 @@ DEFAULT_CAMERA_NUM = 0
 def mock_libraries(mocker):
     mock_libcamera = MagicMock()
     mock_picamera2 = MagicMock()
-    mock_picamera2_encoders = MagicMock()
-    mock_picamera2_outputs = MagicMock()
-    mock_picamera2_outputs.Output = MagicMock
+    mock_picamera2.encoders = MagicMock()
+    mock_picamera2.encoders._hw_encoder_available = False
+    mock_picamera2.outputs = MagicMock()
+    mock_picamera2.outputs.Output = MagicMock
     mocker.patch.dict(
         "sys.modules",
         {
             "libcamera": mock_libcamera,
             "picamera2": mock_picamera2,
-            "picamera2.encoders": mock_picamera2_encoders,
-            "picamera2.outputs": mock_picamera2_outputs,
+            "picamera2.encoders": mock_picamera2.encoders,
+            "picamera2.outputs": mock_picamera2.outputs,
         },
     )
     mocker.patch("libcamera.controls.AfModeEnum.Manual", AF_MODE_ENUM_MANUAL)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,27 +24,22 @@ DEFAULT_TUNING_FILTER_DIR = None
 DEFAULT_CAMERA_NUM = 0
 
 
-@pytest.fixture(autouse=True)
-def mock_libraries(mocker):
-    mock_libcamera = MagicMock()
-    mock_picamera2 = MagicMock()
-    mock_picamera2.encoders = MagicMock()
-    mock_picamera2.encoders._hw_encoder_available = False
-    mock_picamera2.outputs = MagicMock()
-    mock_picamera2.outputs.Output = MagicMock
-    mocker.patch.dict(
-        "sys.modules",
-        {
-            "libcamera": mock_libcamera,
-            "picamera2": mock_picamera2,
-            "picamera2.encoders": mock_picamera2.encoders,
-            "picamera2.outputs": mock_picamera2.outputs,
-        },
-    )
-    mocker.patch("libcamera.controls.AfModeEnum.Manual", AF_MODE_ENUM_MANUAL)
-    mocker.patch("libcamera.controls.AfModeEnum.Continuous", AF_MODE_ENUM_CONTINUOUS)
-    mocker.patch("libcamera.controls.AfSpeedEnum.Normal", AF_SPEED_ENUM_NORMAL)
-    mocker.patch("libcamera.controls.AfSpeedEnum.Fast", AF_SPEED_ENUM_FAST)
+mock_libcamera = MagicMock()
+mock_picamera2 = MagicMock()
+mock_picamera2.encoders._hw_encoder_available = False
+mock_picamera2.outputs.Output = MagicMock
+sys.modules.update(
+    {
+        "libcamera": mock_libcamera,
+        "picamera2": mock_picamera2,
+        "picamera2.encoders": mock_picamera2.encoders,
+        "picamera2.outputs": mock_picamera2.outputs,
+    }
+)
+mock_libcamera.controls.AfModeEnum.Manual = AF_MODE_ENUM_MANUAL
+mock_libcamera.controls.AfModeEnum.Continuous = AF_MODE_ENUM_CONTINUOUS
+mock_libcamera.controls.AfSpeedEnum.Normal = AF_SPEED_ENUM_NORMAL
+mock_libcamera.controls.AfSpeedEnum.Fast = AF_SPEED_ENUM_FAST
 
 
 def test_parse_bindaddress():


### PR DESCRIPTION
Programs like Crowsnest set some default values. Using `store_true` does not allow to negate this flag. This made problems with e.g. `disable_webrtc` for Pi5.
I refactored the WebRTC logic to disable it, if `_hw_encoder_available` is `False`.

Renamed `use-sw-jpg-encoder` to `use-sw-encoder` which also disables WebRTC. This option is still needed, if you want to increase the image size beyond the capabilities of the HW encoder of a Pi.
This also disables WebRTC that it can actually start up with a higher resolution.

I also added the new option `force-webrtc` to force the start of a WebRTC stream, no matter the circumstances. This will still use the HW encoder and therefore fail the startup, if the resolution exceeds the HW capabilities.
But this option will enable support for WebRTC on the Pi5, even if it isn't recommended.

This PR should not break existing setups, but we might remove deprecated options in the future.