### PR TITLE
feat: lazy-start picamera2 encoders and camera to save idle CPU

### DIFF
--- a/resources/spyglass.conf
+++ b/resources/spyglass.conf
@@ -83,3 +83,38 @@ CONTROLS=""
 #### NOTE: Name of the file to be used to apply tuning filter.
 ####       If dir not defined, default pycamera2 directories will be used.
 # TUNING_FILTER="ov5647_noir.json"
+
+#### MJPEG encoder linger (INTEGER)[default: -1]
+#### NOTE: Seconds the MJPEG encoder (and the camera, when no other
+####       encoder is active) keeps running after the last consumer
+####       disconnects. Use 0 or a small positive value to reduce idle
+####       CPU at the cost of cold-start latency on the next /snapshot
+####       or /stream.
+####         -1 keeps the encoder running once started; spyglass
+####            pre-warms it at startup. Preserves the legacy "always
+####            on" behavior and the lowest /snapshot latency (e.g.
+####            for timelapses).
+####          0 stops the encoder immediately when the last consumer
+####            disconnects. Lowest idle CPU.
+####        > 0 stops the encoder N seconds after the last consumer
+####            disconnects; a fresh request within the window cancels
+####            the stop. Bridges brief reconnects without paying
+####            cold-start latency on each one.
+# MJPEG_LINGER_SECONDS="-1"
+
+#### WebRTC encoder linger (INTEGER)[default: 5]
+#### NOTE: Seconds the WebRTC (H264) encoder (and the camera, when no
+####       other encoder is active) keeps running after the last peer
+####       disconnects. Use 0 or a small positive value to reduce idle
+####       CPU at the cost of cold-start latency on the next peer
+####       connection.
+####         -1 keeps the encoder running once started; spyglass
+####            pre-warms it at startup.
+####          0 stops the encoder immediately when the last peer
+####            disconnects. Lowest idle CPU; every new peer pays
+####            cold-start latency.
+####        > 0 (default: 5) stops the encoder N seconds after the
+####            last peer disconnects; a fresh connection within the
+####            window cancels the stop. Bridges brief reconnects
+####            without paying cold-start latency on each one.
+# WEBRTC_LINGER_SECONDS="5"

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -121,8 +121,8 @@ run_spyglass() {
     --orientation_exif "${ORIENTATION_EXIF:-h}" \
     --tuning_filter "${TUNING_FILTER:-}"\
     --tuning_filter_dir "${TUNING_FILTER_DIR:-}" \
-    --mjpeg_linger_seconds "${MJPEG_LINGER_SECONDS:--1}" \
-    --webrtc_linger_seconds "${WEBRTC_LINGER_SECONDS:-5}" \
+    --mjpeg-linger-seconds "${MJPEG_LINGER_SECONDS:--1}" \
+    --webrtc-linger-seconds "${WEBRTC_LINGER_SECONDS:-5}" \
     --controls-string "${CONTROLS:-0=0}" # 0=0 to prevent error on empty string
 }
 

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -121,6 +121,8 @@ run_spyglass() {
     --orientation_exif "${ORIENTATION_EXIF:-h}" \
     --tuning_filter "${TUNING_FILTER:-}"\
     --tuning_filter_dir "${TUNING_FILTER_DIR:-}" \
+    --mjpeg_linger_seconds "${MJPEG_LINGER_SECONDS:--1}" \
+    --webrtc_linger_seconds "${WEBRTC_LINGER_SECONDS:-5}" \
     --controls-string "${CONTROLS:-0=0}" # 0=0 to prevent error on empty string
 }
 

--- a/spyglass/camera/camera.py
+++ b/spyglass/camera/camera.py
@@ -105,6 +105,8 @@ class Camera(ABC):
         webrtc_url="/webrtc",
         orientation_exif=0,
         use_sw_encoding=False,
+        mjpeg_linger_seconds=-1,
+        webrtc_linger_seconds=5,
     ):
         pass
 

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -19,6 +19,8 @@ class CSI(camera.Camera):
         webrtc_url="/webrtc",
         orientation_exif=0,
         use_sw_encoding=False,
+        mjpeg_linger_seconds=-1,
+        webrtc_linger_seconds=5,
     ):
         if _hw_encoder_available and not use_sw_encoding:
             from picamera2.encoders import MJPEGEncoder
@@ -43,20 +45,35 @@ class CSI(camera.Camera):
                 return output.frame
 
         session = CameraSession(self.picam2)
-        StreamingHandler.mjpeg_encoder = LazyEncoder(
-            self.picam2, MJPEGEncoder, FileOutput(output), session=session
+        mjpeg_encoder = LazyEncoder(
+            self.picam2,
+            MJPEGEncoder,
+            FileOutput(output),
+            session=session,
+            linger_seconds=mjpeg_linger_seconds,
         )
+        StreamingHandler.mjpeg_encoder = mjpeg_encoder
         if WEBRTC_ENABLED:
             from picamera2.encoders import H264Encoder
 
-            StreamingHandler.h264_encoder = LazyEncoder(
+            h264_encoder = LazyEncoder(
                 self.picam2,
                 H264Encoder,
                 self.media_track,
                 session=session,
+                linger_seconds=webrtc_linger_seconds,
             )
+            StreamingHandler.h264_encoder = h264_encoder
         else:
             StreamingHandler.h264_encoder = None
+
+        # Linger < 0 means "never stop after first start". Pre-warm so the
+        # first consumer (e.g. a timelapse /snapshot poll) hits the warm path
+        # instead of paying libcamera + AE/AWB cold-start latency.
+        if mjpeg_linger_seconds < 0:
+            mjpeg_encoder.acquire()
+        if WEBRTC_ENABLED and webrtc_linger_seconds < 0:
+            h264_encoder.acquire()
 
         self._run_server(
             bind_address,

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -5,7 +5,7 @@ from picamera2.encoders import _hw_encoder_available
 from picamera2.outputs import FileOutput
 
 from spyglass import WEBRTC_ENABLED, camera
-from spyglass.camera.lazy_encoder import LazyEncoder
+from spyglass.camera.lazy_encoder import CameraSession, LazyEncoder
 from spyglass.server.http_server import StreamingHandler
 
 
@@ -42,18 +42,21 @@ class CSI(camera.Camera):
                 output.condition.wait()
                 return output.frame
 
+        session = CameraSession(self.picam2)
         StreamingHandler.mjpeg_encoder = LazyEncoder(
-            self.picam2, MJPEGEncoder, FileOutput(output)
+            self.picam2, MJPEGEncoder, FileOutput(output), session=session
         )
         if WEBRTC_ENABLED:
             from picamera2.encoders import H264Encoder
 
             StreamingHandler.h264_encoder = LazyEncoder(
-                self.picam2, H264Encoder, self.media_track
+                self.picam2,
+                H264Encoder,
+                self.media_track,
+                session=session,
             )
         else:
             StreamingHandler.h264_encoder = None
-        self.picam2.start()
 
         self._run_server(
             bind_address,
@@ -67,4 +70,13 @@ class CSI(camera.Camera):
         )
 
     def stop(self):
-        self.picam2.stop_recording()
+        # Encoders / camera may already be stopped (no consumers); guard the
+        # systemd shutdown path so we don't error out on that case.
+        try:
+            self.picam2.stop_encoder()
+        except Exception:
+            pass
+        try:
+            self.picam2.stop()
+        except Exception:
+            pass

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -5,6 +5,7 @@ from picamera2.encoders import _hw_encoder_available
 from picamera2.outputs import FileOutput
 
 from spyglass import WEBRTC_ENABLED, camera
+from spyglass.camera.lazy_encoder import LazyEncoder
 from spyglass.server.http_server import StreamingHandler
 
 
@@ -41,11 +42,17 @@ class CSI(camera.Camera):
                 output.condition.wait()
                 return output.frame
 
-        self.picam2.start_encoder(MJPEGEncoder(), FileOutput(output))
+        StreamingHandler.mjpeg_encoder = LazyEncoder(
+            self.picam2, MJPEGEncoder, FileOutput(output)
+        )
         if WEBRTC_ENABLED:
             from picamera2.encoders import H264Encoder
 
-            self.picam2.start_encoder(H264Encoder(), self.media_track)
+            StreamingHandler.h264_encoder = LazyEncoder(
+                self.picam2, H264Encoder, self.media_track
+            )
+        else:
+            StreamingHandler.h264_encoder = None
         self.picam2.start()
 
         self._run_server(

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -67,9 +67,6 @@ class CSI(camera.Camera):
         else:
             StreamingHandler.h264_encoder = None
 
-        # Linger < 0 means "never stop after first start". Pre-warm so the
-        # first consumer (e.g. a timelapse /snapshot poll) hits the warm path
-        # instead of paying libcamera + AE/AWB cold-start latency.
         if mjpeg_linger_seconds < 0:
             mjpeg_encoder.acquire()
         if WEBRTC_ENABLED and webrtc_linger_seconds < 0:
@@ -87,8 +84,6 @@ class CSI(camera.Camera):
         )
 
     def stop(self):
-        # Encoders / camera may already be stopped (no consumers); guard the
-        # systemd shutdown path so we don't error out on that case.
         try:
             self.picam2.stop_encoder()
         except Exception:

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -79,14 +79,10 @@ class LazyEncoder:
         self._refs = 0
         self._lock = threading.Lock()
         self._stop_timer = None
-        # Incremented on every cancel/schedule so a stale timer callback that
-        # has already raced past Timer.cancel() can detect it was superseded.
         self._stop_token = 0
 
     def acquire(self):
         with self._lock:
-            # If a linger-stop is pending, cancel it: the encoder is still
-            # running and we just need to claim a fresh reference.
             self._cancel_linger_locked()
             self._refs += 1
             if self._encoder is None:
@@ -98,7 +94,6 @@ class LazyEncoder:
                     self._encoder = self._encoder_factory()
                     self._picam2.start_encoder(self._encoder, self._output)
                 except Exception:
-                    # Roll back so a future caller can retry.
                     self._refs -= 1
                     self._encoder = None
                     if session_acquired and self._session is not None:
@@ -131,7 +126,6 @@ class LazyEncoder:
         if self._stop_timer is not None:
             self._stop_timer.cancel()
             self._stop_timer = None
-            # Invalidate any in-flight callback that already raced past cancel().
             self._stop_token += 1
 
     def _schedule_linger_locked(self):
@@ -147,7 +141,6 @@ class LazyEncoder:
     def _linger_callback(self, token):
         with self._lock:
             if self._stop_token != token:
-                # Superseded by a cancel or a fresh schedule; bail out.
                 return
             self._stop_timer = None
             if self._refs == 0 and self._encoder is not None:

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -107,7 +107,7 @@ class LazyEncoder:
             if self._refs == 0:
                 return
             self._refs -= 1
-            if self._refs != 0 or self._linger_seconds < 0:
+            if self._refs > 0 or self._linger_seconds < 0:
                 return
             if self._linger_seconds == 0:
                 self._stop_now_locked()

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -107,7 +107,7 @@ class LazyEncoder:
             if self._refs == 0:
                 return
             self._refs -= 1
-            if self._refs != 0 or self._encoder is None or self._linger_seconds < 0:
+            if self._refs != 0 or self._linger_seconds < 0:
                 return
             if self._linger_seconds == 0:
                 self._stop_now_locked()

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -33,12 +33,13 @@ class CameraSession:
     def acquire(self):
         with self._lock:
             self._refs += 1
-            if self._refs == 1:
-                try:
-                    self._picam2.start()
-                except Exception:
-                    self._refs -= 1
-                    raise
+            if self._refs > 1:
+                return
+            try:
+                self._picam2.start()
+            except Exception:
+                self._refs -= 1
+                raise
 
     def release(self):
         with self._lock:
@@ -85,33 +86,35 @@ class LazyEncoder:
         with self._lock:
             self._cancel_linger_locked()
             self._refs += 1
-            if self._encoder is None:
-                session_acquired = False
-                try:
-                    if self._session is not None:
-                        self._session.acquire()
-                        session_acquired = True
-                    self._encoder = self._encoder_factory()
-                    self._picam2.start_encoder(self._encoder, self._output)
-                except Exception:
-                    self._refs -= 1
-                    self._encoder = None
-                    if session_acquired and self._session is not None:
-                        self._session.release()
-                    raise
+            if self._encoder is not None:
+                return
+            session_acquired = False
+            try:
+                if self._session is not None:
+                    self._session.acquire()
+                    session_acquired = True
+                self._encoder = self._encoder_factory()
+                self._picam2.start_encoder(self._encoder, self._output)
+            except Exception:
+                self._refs -= 1
+                self._encoder = None
+                if session_acquired and self._session is not None:
+                    self._session.release()
+                raise
 
     def release(self):
         with self._lock:
             if self._refs == 0:
                 return
             self._refs -= 1
-            if self._refs == 0 and self._encoder is not None:
-                if self._linger_seconds < 0:
-                    return
-                if self._linger_seconds == 0:
-                    self._stop_now_locked()
-                else:
-                    self._schedule_linger_locked()
+            if self._refs != 0 or self._encoder is None:
+                return
+            if self._linger_seconds < 0:
+                return
+            if self._linger_seconds == 0:
+                self._stop_now_locked()
+            else:
+                self._schedule_linger_locked()
 
     def _stop_now_locked(self):
         encoder = self._encoder
@@ -123,10 +126,11 @@ class LazyEncoder:
                 self._session.release()
 
     def _cancel_linger_locked(self):
-        if self._stop_timer is not None:
-            self._stop_timer.cancel()
-            self._stop_timer = None
-            self._stop_token += 1
+        if self._stop_timer is None:
+            return
+        self._stop_timer.cancel()
+        self._stop_timer = None
+        self._stop_token += 1
 
     def _schedule_linger_locked(self):
         self._stop_token += 1

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -107,9 +107,7 @@ class LazyEncoder:
             if self._refs == 0:
                 return
             self._refs -= 1
-            if self._refs != 0 or self._encoder is None:
-                return
-            if self._linger_seconds < 0:
+            if self._refs != 0 or self._encoder is None or self._linger_seconds < 0:
                 return
             if self._linger_seconds == 0:
                 self._stop_now_locked()

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -8,6 +8,17 @@ only runs while at least one consumer (HTTP stream / snapshot / WebRTC
 peer connection) holds a reference. Each LazyEncoder also holds a
 reference on the CameraSession while running, so the camera itself
 turns off when no encoders are active.
+
+LazyEncoder supports a ``linger_seconds`` parameter:
+
+* ``< 0`` keeps the encoder running once started; subsequent releases that
+  drive the ref-count to zero do not stop it. Useful for the MJPEG path
+  when paired with a startup pre-warm so e.g. timelapse snapshots stay on
+  the warm path.
+* ``0`` stops the encoder immediately when the last consumer releases.
+* ``> 0`` schedules a delayed stop; a fresh acquire within the window
+  cancels the pending stop. Useful to bridge brief reconnects without
+  paying the cold-start cost on every reconnect.
 """
 
 import threading
@@ -39,7 +50,14 @@ class CameraSession:
 
 
 class LazyEncoder:
-    def __init__(self, picam2, encoder_factory, output, session=None):
+    def __init__(
+        self,
+        picam2,
+        encoder_factory,
+        output,
+        session=None,
+        linger_seconds=0,
+    ):
         """
         :param picam2: the Picamera2 instance to start/stop the encoder on.
         :param encoder_factory: zero-arg callable returning a fresh Encoder.
@@ -47,19 +65,31 @@ class LazyEncoder:
         :param session: optional CameraSession. If provided, the camera is
             started/stopped together with the encoder so the camera only runs
             when at least one encoder is active.
+        :param linger_seconds: behavior when the last consumer releases. ``0``
+            stops immediately; ``>0`` schedules a stop that is cancelled if a
+            new consumer acquires within the window; ``<0`` keeps the encoder
+            running forever after the first start.
         """
         self._picam2 = picam2
         self._encoder_factory = encoder_factory
         self._output = output
         self._session = session
+        self._linger_seconds = linger_seconds
         self._encoder = None
         self._refs = 0
         self._lock = threading.Lock()
+        self._stop_timer = None
+        # Incremented on every cancel/schedule so a stale timer callback that
+        # has already raced past Timer.cancel() can detect it was superseded.
+        self._stop_token = 0
 
     def acquire(self):
         with self._lock:
+            # If a linger-stop is pending, cancel it: the encoder is still
+            # running and we just need to claim a fresh reference.
+            self._cancel_linger_locked()
             self._refs += 1
-            if self._refs == 1:
+            if self._encoder is None:
                 session_acquired = False
                 try:
                     if self._session is not None:
@@ -81,13 +111,47 @@ class LazyEncoder:
                 return
             self._refs -= 1
             if self._refs == 0 and self._encoder is not None:
-                encoder = self._encoder
-                self._encoder = None
-                try:
-                    self._picam2.stop_encoder(encoder)
-                finally:
-                    if self._session is not None:
-                        self._session.release()
+                if self._linger_seconds < 0:
+                    return
+                if self._linger_seconds == 0:
+                    self._stop_now_locked()
+                else:
+                    self._schedule_linger_locked()
+
+    def _stop_now_locked(self):
+        encoder = self._encoder
+        self._encoder = None
+        try:
+            self._picam2.stop_encoder(encoder)
+        finally:
+            if self._session is not None:
+                self._session.release()
+
+    def _cancel_linger_locked(self):
+        if self._stop_timer is not None:
+            self._stop_timer.cancel()
+            self._stop_timer = None
+            # Invalidate any in-flight callback that already raced past cancel().
+            self._stop_token += 1
+
+    def _schedule_linger_locked(self):
+        self._stop_token += 1
+        token = self._stop_token
+        timer = threading.Timer(
+            self._linger_seconds, self._linger_callback, args=(token,)
+        )
+        timer.daemon = True
+        self._stop_timer = timer
+        timer.start()
+
+    def _linger_callback(self, token):
+        with self._lock:
+            if self._stop_token != token:
+                # Superseded by a cancel or a fresh schedule; bail out.
+                return
+            self._stop_timer = None
+            if self._refs == 0 and self._encoder is not None:
+                self._stop_now_locked()
 
     def __enter__(self):
         self.acquire()

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -1,0 +1,51 @@
+"""Reference-counted lazy start/stop wrapper for picamera2 encoders.
+
+The encoder is only running while at least one consumer holds a reference.
+This avoids burning CPU on encoders that have no clients.
+"""
+
+import threading
+
+
+class LazyEncoder:
+    def __init__(self, picam2, encoder_factory, output):
+        """
+        :param picam2: the Picamera2 instance to start/stop the encoder on.
+        :param encoder_factory: zero-arg callable returning a fresh Encoder.
+        :param output: the picamera2 Output to attach to the encoder.
+        """
+        self._picam2 = picam2
+        self._encoder_factory = encoder_factory
+        self._output = output
+        self._encoder = None
+        self._refs = 0
+        self._lock = threading.Lock()
+
+    def acquire(self):
+        with self._lock:
+            self._refs += 1
+            if self._refs == 1:
+                try:
+                    self._encoder = self._encoder_factory()
+                    self._picam2.start_encoder(self._encoder, self._output)
+                except Exception:
+                    # Roll back so a future caller can retry.
+                    self._refs -= 1
+                    self._encoder = None
+                    raise
+
+    def release(self):
+        with self._lock:
+            if self._refs == 0:
+                return
+            self._refs -= 1
+            if self._refs == 0 and self._encoder is not None:
+                self._picam2.stop_encoder(self._encoder)
+                self._encoder = None
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.release()

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -1,23 +1,21 @@
-"""Reference-counted lazy start/stop wrapper for picamera2 encoders.
+"""Reference-counted lazy start/stop wrappers for picamera2.
 
-The encoder is only running while at least one consumer holds a reference.
-This avoids burning CPU on encoders that have no clients.
+CameraSession wraps Picamera2.start()/stop(): the camera only runs while
+at least one consumer (encoder) holds a reference.
+
+LazyEncoder wraps Picamera2.start_encoder()/stop_encoder(): the encoder
+only runs while at least one consumer (HTTP stream / snapshot / WebRTC
+peer connection) holds a reference. Each LazyEncoder also holds a
+reference on the CameraSession while running, so the camera itself
+turns off when no encoders are active.
 """
 
 import threading
 
 
-class LazyEncoder:
-    def __init__(self, picam2, encoder_factory, output):
-        """
-        :param picam2: the Picamera2 instance to start/stop the encoder on.
-        :param encoder_factory: zero-arg callable returning a fresh Encoder.
-        :param output: the picamera2 Output to attach to the encoder.
-        """
+class CameraSession:
+    def __init__(self, picam2):
         self._picam2 = picam2
-        self._encoder_factory = encoder_factory
-        self._output = output
-        self._encoder = None
         self._refs = 0
         self._lock = threading.Lock()
 
@@ -26,12 +24,55 @@ class LazyEncoder:
             self._refs += 1
             if self._refs == 1:
                 try:
+                    self._picam2.start()
+                except Exception:
+                    self._refs -= 1
+                    raise
+
+    def release(self):
+        with self._lock:
+            if self._refs == 0:
+                return
+            self._refs -= 1
+            if self._refs == 0:
+                self._picam2.stop()
+
+
+class LazyEncoder:
+    def __init__(self, picam2, encoder_factory, output, session=None):
+        """
+        :param picam2: the Picamera2 instance to start/stop the encoder on.
+        :param encoder_factory: zero-arg callable returning a fresh Encoder.
+        :param output: the picamera2 Output to attach to the encoder.
+        :param session: optional CameraSession. If provided, the camera is
+            started/stopped together with the encoder so the camera only runs
+            when at least one encoder is active.
+        """
+        self._picam2 = picam2
+        self._encoder_factory = encoder_factory
+        self._output = output
+        self._session = session
+        self._encoder = None
+        self._refs = 0
+        self._lock = threading.Lock()
+
+    def acquire(self):
+        with self._lock:
+            self._refs += 1
+            if self._refs == 1:
+                session_acquired = False
+                try:
+                    if self._session is not None:
+                        self._session.acquire()
+                        session_acquired = True
                     self._encoder = self._encoder_factory()
                     self._picam2.start_encoder(self._encoder, self._output)
                 except Exception:
                     # Roll back so a future caller can retry.
                     self._refs -= 1
                     self._encoder = None
+                    if session_acquired and self._session is not None:
+                        self._session.release()
                     raise
 
     def release(self):
@@ -40,8 +81,13 @@ class LazyEncoder:
                 return
             self._refs -= 1
             if self._refs == 0 and self._encoder is not None:
-                self._picam2.stop_encoder(self._encoder)
+                encoder = self._encoder
                 self._encoder = None
+                try:
+                    self._picam2.stop_encoder(encoder)
+                finally:
+                    if self._session is not None:
+                        self._session.release()
 
     def __enter__(self):
         self.acquire()

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -12,7 +12,11 @@ class USB(camera.Camera):
         webrtc_url="/webrtc",
         orientation_exif=0,
         use_sw_encoding=False,
+        mjpeg_linger_seconds=-1,
+        webrtc_linger_seconds=5,
     ):
+        # USB camera path does not use lazy encoders; linger args are accepted
+        # for signature compatibility but ignored.
         def get_frame(inner_self):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer
             return self.picam2.capture_buffer()

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -15,8 +15,6 @@ class USB(camera.Camera):
         mjpeg_linger_seconds=-1,
         webrtc_linger_seconds=5,
     ):
-        # USB camera path does not use lazy encoders; linger args are accepted
-        # for signature compatibility but ignored.
         def get_frame(inner_self):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer
             return self.picam2.capture_buffer()

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -350,7 +350,6 @@ def get_parser():
     )
     parser.add_argument(
         "--mjpeg-linger-seconds",
-        "--mjpeg_linger_seconds",
         type=int,
         default=-1,
         help="How long the MJPEG encoder (and the camera, when no other "
@@ -371,7 +370,6 @@ def get_parser():
     )
     parser.add_argument(
         "--webrtc-linger-seconds",
-        "--webrtc_linger_seconds",
         type=int,
         default=5,
         help="How long the WebRTC (H264) encoder (and the camera, when no "

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -100,6 +100,8 @@ def main(args=None):
             parsed_args.webrtc_url,
             parsed_args.orientation_exif,
             use_sw_encoding,
+            mjpeg_linger_seconds=parsed_args.mjpeg_linger_seconds,
+            webrtc_linger_seconds=parsed_args.webrtc_linger_seconds,
         )
     finally:
         cam.stop()
@@ -345,6 +347,47 @@ def get_parser():
         "--list-controls",
         action="store_true",
         help="List available camera controls and exits.",
+    )
+    parser.add_argument(
+        "--mjpeg-linger-seconds",
+        "--mjpeg_linger_seconds",
+        type=int,
+        default=-1,
+        help="How long the MJPEG encoder (and the camera, when no other "
+        "encoder is active) keeps running after the last consumer "
+        "disconnects. Use 0 or a small positive value to free encoder and "
+        "camera resources while idle, reducing CPU use at the cost of "
+        "cold-start latency on the next /snapshot or /stream.\n"
+        "  -1 (default) keeps the encoder running once started; spyglass "
+        "pre-warms it at startup. Preserves the legacy 'always on' "
+        "behavior and the lowest /snapshot latency (e.g. for timelapse "
+        "use cases).\n"
+        "   0 stops the encoder immediately when the last consumer "
+        "disconnects. Lowest idle CPU.\n"
+        " > 0 stops the encoder N seconds after the last consumer "
+        "disconnects; a fresh request within the window cancels the stop. "
+        "Bridges brief reconnects without paying cold-start latency on "
+        "each one.",
+    )
+    parser.add_argument(
+        "--webrtc-linger-seconds",
+        "--webrtc_linger_seconds",
+        type=int,
+        default=5,
+        help="How long the WebRTC (H264) encoder (and the camera, when no "
+        "other encoder is active) keeps running after the last peer "
+        "disconnects. Use 0 or a small positive value to free encoder and "
+        "camera resources while idle, reducing CPU use at the cost of "
+        "cold-start latency on the next peer connection.\n"
+        "  -1 keeps the encoder running once started; spyglass pre-warms "
+        "it at startup.\n"
+        "   0 stops the encoder immediately when the last peer "
+        "disconnects. Lowest idle CPU; every new peer pays cold-start "
+        "latency.\n"
+        " > 0 (default: 5) stops the encoder N seconds after the last "
+        "peer disconnects; a fresh connection within the window cancels "
+        "the stop. Bridges brief reconnects without paying cold-start "
+        "latency on each one.",
     )
     camera_group = parser.add_mutually_exclusive_group()
     camera_group.add_argument(

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -100,8 +100,8 @@ def main(args=None):
             parsed_args.webrtc_url,
             parsed_args.orientation_exif,
             use_sw_encoding,
-            mjpeg_linger_seconds=parsed_args.mjpeg_linger_seconds,
-            webrtc_linger_seconds=parsed_args.webrtc_linger_seconds,
+            parsed_args.mjpeg_linger_seconds,
+            parsed_args.webrtc_linger_seconds,
         )
     finally:
         cam.stop()

--- a/spyglass/server/jpeg.py
+++ b/spyglass/server/jpeg.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
 
 
 def start_streaming(handler: "StreamingHandler"):
+    encoder = getattr(handler, "mjpeg_encoder", None)
+    if encoder is not None:
+        encoder.acquire()
     try:
         send_default_headers(handler)
         handler.send_header("Content-Type", "multipart/x-mixed-replace; boundary=FRAME")
@@ -30,9 +33,15 @@ def start_streaming(handler: "StreamingHandler"):
         logger.warning(
             "Removed streaming client %s: %s", handler.client_address, str(e)
         )
+    finally:
+        if encoder is not None:
+            encoder.release()
 
 
 def send_snapshot(handler: "StreamingHandler"):
+    encoder = getattr(handler, "mjpeg_encoder", None)
+    if encoder is not None:
+        encoder.acquire()
     try:
         send_default_headers(handler)
         frame = handler.get_frame()
@@ -45,6 +54,9 @@ def send_snapshot(handler: "StreamingHandler"):
             handler.wfile.write(frame[2:])
     except Exception as e:
         logger.warning("Removed client %s: %s", handler.client_address, str(e))
+    finally:
+        if encoder is not None:
+            encoder.release()
 
 
 def send_default_headers(handler: "StreamingHandler"):

--- a/spyglass/server/webrtc_whep.py
+++ b/spyglass/server/webrtc_whep.py
@@ -77,46 +77,72 @@ async def do_POST_async(handler: "StreamingHandler"):
     pc = RTCPeerConnection()
     secret = uuid.uuid4()
 
+    h264_encoder = getattr(handler, "h264_encoder", None)
+    encoder_acquired = False
+    encoder_released = False
+
+    def _release_encoder_once():
+        nonlocal encoder_released
+        if (
+            h264_encoder is not None
+            and encoder_acquired
+            and not encoder_released
+        ):
+            encoder_released = True
+            h264_encoder.release()
+
     @pc.on("connectionstatechange")
     async def on_connectionstatechange():
         print(f"Connection state {pc.connectionState}")
         if pc.connectionState == "failed":
             await pc.close()
         elif pc.connectionState == "closed":
-            pcs.pop(str(secret))
+            pcs.pop(str(secret), None)
+            _release_encoder_once()
             print(f"{len(pcs)} connections still open.")
 
-    pcs[str(secret)] = pc
-    track = media_relay.subscribe(handler.media_track)
-    sender = pc.addTrack(track)
-    codecs = RTCRtpSender.getCapabilities("video").codecs
-    transceiver = next(t for t in pc.getTransceivers() if t.sender == sender)
-    transceiver.setCodecPreferences(
-        [codec for codec in codecs if codec.mimeType == "video/H264"]
-    )
+    try:
+        if h264_encoder is not None:
+            h264_encoder.acquire()
+            encoder_acquired = True
 
-    await pc.setRemoteDescription(offer)
-    answer = await pc.createAnswer()
-    await pc.setLocalDescription(answer)
+        pcs[str(secret)] = pc
 
-    while pc.iceGatheringState != "complete":
-        await asyncio.sleep(1)
+        track = media_relay.subscribe(handler.media_track)
+        sender = pc.addTrack(track)
+        codecs = RTCRtpSender.getCapabilities("video").codecs
+        transceiver = next(t for t in pc.getTransceivers() if t.sender == sender)
+        transceiver.setCodecPreferences(
+            [codec for codec in codecs if codec.mimeType == "video/H264"]
+        )
 
-    send_default_headers(HTTPStatus.CREATED, handler)
+        await pc.setRemoteDescription(offer)
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
 
-    handler.send_header("Content-Type", "application/sdp")
-    handler.send_header("ETag", "*")
+        while pc.iceGatheringState != "complete":
+            await asyncio.sleep(1)
 
-    handler.send_header("ID", secret)
-    handler.send_header(
-        "Access-Control-Expose-Headers", "ETag, ID, Accept-Patch, Link, Location"
-    )
-    handler.send_header("Accept-Patch", "application/trickle-ice-sdpfrag")
-    handler.headers["Link"] = get_ICE_servers()
-    handler.send_header("Location", f"/whep/{secret}")
-    handler.send_header("Content-Length", len(pc.localDescription.sdp))
-    handler.end_headers()
-    handler.wfile.write(bytes(pc.localDescription.sdp, "utf-8"))
+        send_default_headers(HTTPStatus.CREATED, handler)
+
+        handler.send_header("Content-Type", "application/sdp")
+        handler.send_header("ETag", "*")
+
+        handler.send_header("ID", secret)
+        handler.send_header(
+            "Access-Control-Expose-Headers", "ETag, ID, Accept-Patch, Link, Location"
+        )
+        handler.send_header("Accept-Patch", "application/trickle-ice-sdpfrag")
+        handler.headers["Link"] = get_ICE_servers()
+        handler.send_header("Location", f"/whep/{secret}")
+        handler.send_header("Content-Length", len(pc.localDescription.sdp))
+        handler.end_headers()
+        handler.wfile.write(bytes(pc.localDescription.sdp, "utf-8"))
+    except Exception:
+        pcs.pop(str(secret), None)
+        _release_encoder_once()
+        await pc.close()
+        raise
 
 
 async def do_PATCH_async(streaming_handler: "StreamingHandler"):

--- a/spyglass/server/webrtc_whep.py
+++ b/spyglass/server/webrtc_whep.py
@@ -79,16 +79,12 @@ async def do_POST_async(handler: "StreamingHandler"):
 
     h264_encoder = getattr(handler, "h264_encoder", None)
     encoder_acquired = False
-    encoder_released = False
 
-    def _release_encoder_once():
-        nonlocal encoder_released
-        if (
-            h264_encoder is not None
-            and encoder_acquired
-            and not encoder_released
-        ):
-            encoder_released = True
+    def _cleanup():
+        nonlocal encoder_acquired
+        pcs.pop(str(secret), None)
+        if h264_encoder is not None and encoder_acquired:
+            encoder_acquired = False
             h264_encoder.release()
 
     @pc.on("connectionstatechange")
@@ -97,8 +93,7 @@ async def do_POST_async(handler: "StreamingHandler"):
         if pc.connectionState == "failed":
             await pc.close()
         elif pc.connectionState == "closed":
-            pcs.pop(str(secret), None)
-            _release_encoder_once()
+            _cleanup()
             print(f"{len(pcs)} connections still open.")
 
     try:
@@ -139,8 +134,7 @@ async def do_POST_async(handler: "StreamingHandler"):
         handler.end_headers()
         handler.wfile.write(bytes(pc.localDescription.sdp, "utf-8"))
     except Exception:
-        pcs.pop(str(secret), None)
-        _release_encoder_once()
+        _cleanup()
         await pc.close()
         raise
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,8 @@ DEFAULT_CONTROLS = []
 DEFAULT_TUNING_FILTER = None
 DEFAULT_TUNING_FILTER_DIR = None
 DEFAULT_CAMERA_NUM = 0
+DEFAULT_MJPEG_LINGER_SECONDS = -1
+DEFAULT_WEBRTC_LINGER_SECONDS = 5
 
 
 mock_libcamera = MagicMock()
@@ -83,6 +85,53 @@ def test_parse_tuning_filter_dir():
 
     args = cli.get_args(["-tfd", "dir"])
     assert args.tuning_filter_dir == "dir"
+
+
+def test_parse_linger_defaults():
+    from spyglass import cli
+
+    args = cli.get_args([])
+    assert args.mjpeg_linger_seconds == DEFAULT_MJPEG_LINGER_SECONDS
+    assert args.webrtc_linger_seconds == DEFAULT_WEBRTC_LINGER_SECONDS
+
+
+def test_parse_linger_overrides():
+    from spyglass import cli
+
+    args = cli.get_args(
+        ["--mjpeg-linger-seconds", "10", "--webrtc-linger-seconds", "0"]
+    )
+    assert args.mjpeg_linger_seconds == 10
+    assert args.webrtc_linger_seconds == 0
+
+
+def test_parse_linger_overrides_underscore_aliases():
+    from spyglass import cli
+
+    args = cli.get_args(
+        ["--mjpeg_linger_seconds", "-1", "--webrtc_linger_seconds", "30"]
+    )
+    assert args.mjpeg_linger_seconds == -1
+    assert args.webrtc_linger_seconds == 30
+
+
+@patch("spyglass.camera.init_camera")
+def test_run_server_forwards_linger_arguments(mock_init_camera):
+    from spyglass import cli
+
+    cli.main(
+        args=[
+            "--mjpeg-linger-seconds",
+            "0",
+            "--webrtc-linger-seconds",
+            "30",
+            "-sw",
+        ]
+    )
+    cam_instance = mock_init_camera.return_value
+    _, kwargs = cam_instance.start_and_run_server.call_args
+    assert kwargs["mjpeg_linger_seconds"] == 0
+    assert kwargs["webrtc_linger_seconds"] == 30
 
 
 @patch("spyglass.camera.init_camera")
@@ -206,7 +255,15 @@ def test_run_server_with_configuration_from_arguments(mock_init_camera):
     )
     cam_instance = mock_init_camera.return_value
     cam_instance.start_and_run_server.assert_called_once_with(
-        "1.2.3.4", 1234, "streaming-url", "snapshot-url", "webrtc-url", 1, True
+        "1.2.3.4",
+        1234,
+        "streaming-url",
+        "snapshot-url",
+        "webrtc-url",
+        1,
+        True,
+        mjpeg_linger_seconds=DEFAULT_MJPEG_LINGER_SECONDS,
+        webrtc_linger_seconds=DEFAULT_WEBRTC_LINGER_SECONDS,
     )
 
 
@@ -253,4 +310,6 @@ def test_run_server_with_orientation(mock_init_camera, input_value, expected_out
         "webrtc-url",
         expected_output,
         True,
+        mjpeg_linger_seconds=DEFAULT_MJPEG_LINGER_SECONDS,
+        webrtc_linger_seconds=DEFAULT_WEBRTC_LINGER_SECONDS,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,53 +87,6 @@ def test_parse_tuning_filter_dir():
     assert args.tuning_filter_dir == "dir"
 
 
-def test_parse_linger_defaults():
-    from spyglass import cli
-
-    args = cli.get_args([])
-    assert args.mjpeg_linger_seconds == DEFAULT_MJPEG_LINGER_SECONDS
-    assert args.webrtc_linger_seconds == DEFAULT_WEBRTC_LINGER_SECONDS
-
-
-def test_parse_linger_overrides():
-    from spyglass import cli
-
-    args = cli.get_args(
-        ["--mjpeg-linger-seconds", "10", "--webrtc-linger-seconds", "0"]
-    )
-    assert args.mjpeg_linger_seconds == 10
-    assert args.webrtc_linger_seconds == 0
-
-
-def test_parse_linger_overrides_underscore_aliases():
-    from spyglass import cli
-
-    args = cli.get_args(
-        ["--mjpeg_linger_seconds", "-1", "--webrtc_linger_seconds", "30"]
-    )
-    assert args.mjpeg_linger_seconds == -1
-    assert args.webrtc_linger_seconds == 30
-
-
-@patch("spyglass.camera.init_camera")
-def test_run_server_forwards_linger_arguments(mock_init_camera):
-    from spyglass import cli
-
-    cli.main(
-        args=[
-            "--mjpeg-linger-seconds",
-            "0",
-            "--webrtc-linger-seconds",
-            "30",
-            "-sw",
-        ]
-    )
-    cam_instance = mock_init_camera.return_value
-    _, kwargs = cam_instance.start_and_run_server.call_args
-    assert kwargs["mjpeg_linger_seconds"] == 0
-    assert kwargs["webrtc_linger_seconds"] == 30
-
-
 @patch("spyglass.camera.init_camera")
 def test_init_camera_with_defaults(
     mock_spyglass_camera,
@@ -262,8 +215,8 @@ def test_run_server_with_configuration_from_arguments(mock_init_camera):
         "webrtc-url",
         1,
         True,
-        mjpeg_linger_seconds=DEFAULT_MJPEG_LINGER_SECONDS,
-        webrtc_linger_seconds=DEFAULT_WEBRTC_LINGER_SECONDS,
+        DEFAULT_MJPEG_LINGER_SECONDS,
+        DEFAULT_WEBRTC_LINGER_SECONDS,
     )
 
 
@@ -310,6 +263,6 @@ def test_run_server_with_orientation(mock_init_camera, input_value, expected_out
         "webrtc-url",
         expected_output,
         True,
-        mjpeg_linger_seconds=DEFAULT_MJPEG_LINGER_SECONDS,
-        webrtc_linger_seconds=DEFAULT_WEBRTC_LINGER_SECONDS,
+        DEFAULT_MJPEG_LINGER_SECONDS,
+        DEFAULT_WEBRTC_LINGER_SECONDS,
     )

--- a/tests/test_lazy_encoder.py
+++ b/tests/test_lazy_encoder.py
@@ -1,0 +1,195 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from spyglass.camera.lazy_encoder import CameraSession, LazyEncoder
+
+
+def _make(picam2=None, *, session=None, linger_seconds=0):
+    if picam2 is None:
+        picam2 = MagicMock()
+    if session is None:
+        session = CameraSession(picam2)
+    encoder_factory = MagicMock()
+    output = MagicMock()
+    lazy = LazyEncoder(
+        picam2,
+        encoder_factory,
+        output,
+        session=session,
+        linger_seconds=linger_seconds,
+    )
+    return lazy, picam2, session, encoder_factory, output
+
+
+def test_first_acquire_starts_session_then_encoder():
+    lazy, picam2, _, factory, output = _make()
+    lazy.acquire()
+
+    picam2.start.assert_called_once_with()
+    picam2.start_encoder.assert_called_once_with(factory.return_value, output)
+
+
+def test_extra_acquires_share_encoder_and_session():
+    lazy, picam2, _, _, _ = _make()
+    lazy.acquire()
+    lazy.acquire()
+    lazy.acquire()
+
+    picam2.start.assert_called_once()
+    picam2.start_encoder.assert_called_once()
+
+
+def test_release_with_linger_zero_stops_immediately():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0)
+    lazy.acquire()
+    lazy.release()
+
+    picam2.stop_encoder.assert_called_once()
+    picam2.stop.assert_called_once_with()
+
+
+def test_release_with_linger_negative_keeps_running():
+    lazy, picam2, _, _, _ = _make(linger_seconds=-1)
+    lazy.acquire()
+    lazy.release()
+
+    picam2.stop_encoder.assert_not_called()
+    picam2.stop.assert_not_called()
+
+
+def test_linger_negative_subsequent_acquire_does_not_restart_encoder():
+    lazy, picam2, _, _, _ = _make(linger_seconds=-1)
+    lazy.acquire()
+    lazy.release()
+    lazy.acquire()
+
+    picam2.start.assert_called_once()
+    picam2.start_encoder.assert_called_once()
+
+
+def test_release_with_positive_linger_does_not_stop_immediately():
+    lazy, picam2, _, _, _ = _make(linger_seconds=10)
+    lazy.acquire()
+    lazy.release()
+
+    assert lazy._stop_timer is not None
+    picam2.stop_encoder.assert_not_called()
+    picam2.stop.assert_not_called()
+
+    lazy._stop_timer.cancel()  # clean up so the test process exits cleanly
+
+
+def test_acquire_cancels_pending_linger_stop():
+    lazy, picam2, _, _, _ = _make(linger_seconds=10)
+    lazy.acquire()
+    lazy.release()
+    assert lazy._stop_timer is not None
+
+    lazy.acquire()
+    assert lazy._stop_timer is None
+    picam2.stop_encoder.assert_not_called()
+
+
+def test_positive_linger_eventually_stops():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0.05)
+    lazy.acquire()
+    lazy.release()
+
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline and picam2.stop_encoder.call_count == 0:
+        time.sleep(0.01)
+
+    picam2.stop_encoder.assert_called_once()
+    picam2.stop.assert_called_once()
+
+
+def test_release_at_zero_refs_is_noop():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0)
+    lazy.release()  # never acquired
+
+    picam2.start.assert_not_called()
+    picam2.stop_encoder.assert_not_called()
+
+
+def test_acquire_rolls_back_when_start_encoder_fails():
+    picam2 = MagicMock()
+    picam2.start_encoder.side_effect = RuntimeError("boom")
+    lazy, _, session, _, _ = _make(picam2=picam2, linger_seconds=0)
+
+    with pytest.raises(RuntimeError):
+        lazy.acquire()
+
+    # Both refs rolled back; camera was stopped via session.release().
+    assert session._refs == 0
+    picam2.start.assert_called_once()
+    picam2.stop.assert_called_once()
+
+    # A retry succeeds.
+    picam2.start_encoder.side_effect = None
+    lazy.acquire()
+    assert picam2.start_encoder.call_count == 2
+
+
+def test_release_still_releases_session_if_stop_encoder_raises():
+    picam2 = MagicMock()
+    picam2.stop_encoder.side_effect = RuntimeError("boom")
+    lazy, _, session, _, _ = _make(picam2=picam2, linger_seconds=0)
+
+    lazy.acquire()
+    with pytest.raises(RuntimeError):
+        lazy.release()
+
+    assert session._refs == 0
+    picam2.stop.assert_called_once()
+
+
+def test_two_encoders_share_one_session():
+    picam2 = MagicMock()
+    session = CameraSession(picam2)
+    mjpeg, _, _, _, _ = _make(picam2=picam2, session=session, linger_seconds=0)
+    h264, _, _, _, _ = _make(picam2=picam2, session=session, linger_seconds=0)
+
+    mjpeg.acquire()
+    h264.acquire()
+    picam2.start.assert_called_once()
+
+    mjpeg.release()
+    picam2.stop.assert_not_called()
+
+    h264.release()
+    picam2.stop.assert_called_once()
+
+
+def test_stale_timer_callback_after_cancel_is_ignored():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0.05)
+    lazy.acquire()
+    lazy.release()
+    # Acquire before the timer can fire to cancel the stop.
+    lazy.acquire()
+
+    # Give a stale callback time to try to run.
+    time.sleep(0.15)
+
+    picam2.stop_encoder.assert_not_called()
+    picam2.stop.assert_not_called()
+
+
+def test_reacquire_after_full_stop_starts_again():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0)
+    lazy.acquire()
+    lazy.release()
+    lazy.acquire()
+
+    assert picam2.start.call_count == 2
+    assert picam2.start_encoder.call_count == 2
+
+
+def test_context_manager_acquires_and_releases():
+    lazy, picam2, _, _, _ = _make(linger_seconds=0)
+    with lazy:
+        picam2.start_encoder.assert_called_once()
+        picam2.stop_encoder.assert_not_called()
+
+    picam2.stop_encoder.assert_called_once()


### PR DESCRIPTION
## Use of AI

This PR was written using GitHub Copilot CLI with Claude Opus 4.7. I understand different projects have different policies wrt to AI generated code. Do let me know if this is not ok for this project. From reviewing the code changes as well as the resulting CPU usage numbers and continued usability from mainsail / direct http consumption, I can confirm this is having the desired effect.

I do not have any prior experience on this repo so please do share feedback if anything was missed of if this is taking a completely wrong approach.

## Summary

Spyglass currently starts the MJPEG encoder, the H264 encoder (when WebRTC is enabled), and the picamera2 capture loop unconditionally at server startup. They run continuously regardless of whether any client is connected. On a Pi 4B with a Camera Module 3 at 1920x1080 @ 30 FPS this costs ~95-100% of one CPU core at idle (and ~120-135% during a live WebRTC session, since the unused MJPEG encoder runs in parallel).

This PR adds reference-counted lazy start/stop:

- **Commit 1** (`feat: lazy-start picamera2 encoders to save idle CPU`) — wraps `start_encoder`/`stop_encoder` in a small `LazyEncoder`. MJPEG is acquired by `/stream` and `/snapshot`; H264 is acquired by the WHEP `POST` and released on `RTCPeerConnection` close.
- **Commit 2** (`feat: stop the picamera2 capture loop when no consumers`) — adds a `CameraSession` that does the same for `picam2.start()`/`picam2.stop()`, so the camera itself stops when no encoders are active.

## Measured CPU impact

Raspberry Pi 4B, Camera Module 3, hardware encoders, sampled with \`top\` (percentages of one core; >100% means the process spans multiple cores):

| Config | State | Before | After |
|---|---|---|---|
| 640x480 @ 15 FPS | Idle | ~13-15% | **~0%** |
| 640x480 @ 15 FPS | Live MJPEG | ~13-15% | ~9% |
| 640x480 @ 15 FPS | Live WebRTC | ~25-30% | ~10-11% |
| 1920x1080 @ 30 FPS | Idle | ~95-100% | **~0%** |
| 1920x1080 @ 30 FPS | Live MJPEG only | ~95-104% | ~50-60% |
| 1920x1080 @ 30 FPS | Live WebRTC only | ~120-135% | ~60% |

The biggest wins come from two effects: idle no longer pays for either encoder + the capture loop, and a live single-protocol client no longer pays for the unused other encoder.

## Cold-start latency

Cold-start `/snapshot` at 1080p30 (camera off → on → first JPEG): **~150-500 ms**, dominated by libcamera sensor init and AE/AWB warm-up. The first cold start after process boot is typically slowest (~500 ms); subsequent cold starts are faster (~150-200 ms).

This is an acceptable tradeoff for the idle savings; in practice Mainsail/Fluidd dashboards either keep a long-lived WebRTC stream open (one cold start per session) or poll `/snapshot` at a cadence where 100-200 ms is invisible.

## Tested

- All 129 existing unit tests pass.
- Smoke tested on a Pi 4B:
  - Idle (no clients) → camera fully stopped, 0% CPU, no errors in journal.
  - `/snapshot` → returns valid JPEG, camera starts and stops cleanly per request.
  - `/stream` (MJPEG) → starts encoder on connect, releases on disconnect.
  - `/webrtc/whep` from Mainsail → live video, encoder released on tab close (`Camera stopped` in log).

## Possible follow-ups (not in this PR)

- Optional `--camera-linger-seconds` flag so consecutive snapshots within a window reuse a warm camera. Skipped here because the cold-start cost is small (~100-150 ms) and it adds non-trivial complexity (timer races, default-value debate). Easy to add later if there's demand.
- Stop the USB-camera capture loop too (currently unaffected; that path doesn't use encoders).