### PR TITLE
refactor: update cli arguments to use hyphenated naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,21 +114,21 @@ On startup the following arguments are supported:
 | `-p`, `--port`                 | Port where the server will listen for incoming connections.                                                                        | `8080`       |
 | `-r`, `--resolution`           | Resolution of the captured frames. This argument expects the format \<width\>x\<height\>.                                          | `640x480`    |
 | `-f`, `--fps`                  | Framerate in frames per second (FPS).                                                                                              | `15`         |
-| `-st`, `--stream_url`          | Set the URL for the mjpeg stream.                                                                                                  | `/stream`    |
-| `-sn`, `--snapshot_url`        | Set the URL for snapshots (single frame of stream).                                                                                | `/snapshot`  |
-| `-w`, `--webrtc_url`           | Set  the URL for WebRTC (H264 compressed stream).                                                                                  | `/webrtc`    |
+| `-st`, `--stream-url`          | Set the URL for the mjpeg stream.                                                                                                  | `/stream`    |
+| `-sn`, `--snapshot-url`        | Set the URL for snapshots (single frame of stream).                                                                                | `/snapshot`  |
+| `-w`, `--webrtc-url`           | Set  the URL for WebRTC (H264 compressed stream).                                                                                  | `/webrtc`    |
 | `-af`, `--autofocus`           | Autofocus mode. Supported modes: `manual`, `continuous`.                                                                           | `continuous` |
 | `-l`, `--lensposition`         | Set focal distance. 0 for infinite focus, 0.5 for approximate 50cm. Only used with Autofocus manual.                               | `0.0`        |
 | `-s`, `--autofocusspeed`       | Autofocus speed. Supported values: `normal`, `fast`. Only used with Autofocus continuous.                                          | `normal`     |
 | `-ud`, `--upsidedown`          | Rotate the image by 180° (see [below](#image-orientation)).                                                                        |              |
-| `-fh`, `--flip_horizontal`     | Mirror the image horizontally (see [below](#image-orientation)).                                                                   |              |
-| `-fv`, `--flip_vertical`       | Mirror the image vertically (see [below](#image-orientation)).                                                                     |              |
-| `-or`, `--orientation_exif`    | Set the image orientation using an EXIF header (see [below](#image-orientation)).                                                  |              |
+| `-fh`, `--flip-horizontal`     | Mirror the image horizontally (see [below](#image-orientation)).                                                                   |              |
+| `-fv`, `--flip-vertical`       | Mirror the image vertically (see [below](#image-orientation)).                                                                     |              |
+| `-or`, `--orientation-exif`    | Set the image orientation using an EXIF header (see [below](#image-orientation)).                                                  |              |
 | `-c`, `--controls`             | Define camera controls to start spyglass with. Can be used multiple times. This argument expects the format \<control\>=\<value\>. |              |
-| `-tf`, `--tuning_filter`       | Set a tuning filter file name.                                                                                                     |              |
-| `-tfd`, `--tuning_filter_dir`  | Set the directory to look for tuning filters.                                                                                      |              |
-| `-n`, `--camera_num`           | Camera number to be used. All cameras with their number can be shown with `libcamera-hello`.                                       | `0`          |
-| `-sw`, `--use_sw_encoding`     | Use software encoding for JPEG and MJPG (Disables WebRTC).                                                                         |              |
+| `-tf`, `--tuning-filter`       | Set a tuning filter file name.                                                                                                     |              |
+| `-tfd`, `--tuning-filter-dir`  | Set the directory to look for tuning filters.                                                                                      |              |
+| `-n`, `--camera-num`           | Camera number to be used. All cameras with their number can be shown with `libcamera-hello`.                                       | `0`          |
+| `-sw`, `--use-sw-encoding`     | Use software encoding for JPEG and MJPG (Disables WebRTC).                                                                         |              |
 | `--force-webrtc`               | Force WebRTC streaming to start.                                                                                                   |              |
 | `--list-controls`              | List all available libcamera controls onto the console. Those can be used with `--controls`.                                       |              |
 
@@ -166,15 +166,15 @@ There are two ways to change the image orientation.
 
 To use the ability of picamera2 to transform the image you can use the following options when starting spyglass:
  * `-ud` or `--upsidedown` - Rotate the image by 180°
- * `-fh` or `--flip_horizontal` - Mirror the image horizontally
- * `-fv` or `--flip_vertical` - Mirror the image vertically
+ * `-fh` or `--flip-horizontal` - Mirror the image horizontally
+ * `-fv` or `--flip-vertical` - Mirror the image vertically
 
 This will work with all endpoints Spyglass offers.
 
 Alternatively you can create an EXIF header to modify the image orientation. Most modern browsers should respect
 the exif header. This will only work for the MJPG and JPEG endpoints.
 
-Use the `-or` or `--orientation_exif` option and choose from one of the following orientations
+Use the `-or` or `--orientation-exif` option and choose from one of the following orientations
  * `h` - Horizontal (normal)
  * `mh` - Mirror horizontal
  * `r180` - Rotate 180
@@ -201,9 +201,9 @@ Predefined filters can be found at one of the picamera2 directories:
 - `/usr/share/libcamera/ipa/rpi/vc4`
 - `/usr/share/libcamera/ipa/raspberrypi`
 
-You can use all the files present in there in our config, e.g.: `--tuning_filter=ov5647_noir.json`
+You can use all the files present in there in our config, e.g.: `--tuning-filter=ov5647_noir.json`
 
-You can also define your own directory for filters using the `--tuning_filter_dir` argument.
+You can also define your own directory for filters using the `--tuning-filter-dir` argument.
 
 ### How to use the WebRTC endpoint?
 

--- a/scripts/spyglass
+++ b/scripts/spyglass
@@ -96,7 +96,7 @@ run_spyglass() {
     # For backwards compatibility, USE_SW_JPG_ENCODING will be checked here
     # Might get removed in future
     if [[ "${USE_SW_ENCODING:-false}" == "true" || "${USE_SW_JPG_ENCODING:-false}" == "true" ]]; then
-        use_sw_encoding="--use_sw_encoding"
+        use_sw_encoding="--use-sw-encoding"
     fi
 
     force_webrtc=""
@@ -105,22 +105,22 @@ run_spyglass() {
     fi
 
     "${PY_BIN}" "$(dirname "${BASE_SPY_PATH}")/run.py" \
-    --camera_num "${CAMERA_NUM:-0}" \
+    --camera-num "${CAMERA_NUM:-0}" \
     --bindaddress "${bind_adress}" \
     --port "${HTTP_PORT:-8080}" \
     --resolution "${RESOLUTION:-640x480}" \
     --fps "${FPS:-15}" \
-    --stream_url "${STREAM_URL:-/stream}" \
-    --snapshot_url "${SNAPSHOT_URL:-/snapshot}" \
+    --stream-url "${STREAM_URL:-/stream}" \
+    --snapshot-url "${SNAPSHOT_URL:-/snapshot}" \
     ${use_sw_encoding} \
-    --webrtc_url "${WEBRTC_URL:-/webrtc}" \
+    --webrtc-url "${WEBRTC_URL:-/webrtc}" \
     ${force_webrtc} \
     --autofocus "${AUTO_FOCUS:-continuous}" \
     --lensposition "${FOCAL_DIST:-0.0}" \
     --autofocusspeed "${AF_SPEED:-normal}" \
-    --orientation_exif "${ORIENTATION_EXIF:-h}" \
-    --tuning_filter "${TUNING_FILTER:-}"\
-    --tuning_filter_dir "${TUNING_FILTER_DIR:-}" \
+    --orientation-exif "${ORIENTATION_EXIF:-h}" \
+    --tuning-filter "${TUNING_FILTER:-}"\
+    --tuning-filter-dir "${TUNING_FILTER_DIR:-}" \
     --mjpeg-linger-seconds "${MJPEG_LINGER_SECONDS:--1}" \
     --webrtc-linger-seconds "${WEBRTC_LINGER_SECONDS:-5}" \
     --controls-string "${CONTROLS:-0=0}" # 0=0 to prevent error on empty string


### PR DESCRIPTION
Changing the script to call the hyphenated naming scheme cli args introduced by #140 