### PR TITLE
feat: add quality parameter for streams

### DIFF
--- a/spyglass/camera/camera.py
+++ b/spyglass/camera/camera.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import libcamera
 from picamera2 import Picamera2
+from picamera2.encoders import Quality
 
 from spyglass import WEBRTC_ENABLED, logger
 from spyglass.camera_options import process_controls
@@ -114,6 +115,8 @@ class Camera(ABC):
         use_sw_encoding=False,
         mjpeg_linger_seconds=-1,
         webrtc_linger_seconds=5,
+        mjpg_quality: Quality | None = None,
+        h264_quality: Quality | None = None,
     ):
         pass
 

--- a/spyglass/camera/csi.py
+++ b/spyglass/camera/csi.py
@@ -2,7 +2,7 @@ import io
 from threading import Condition
 
 import libcamera
-from picamera2.encoders import _hw_encoder_available
+from picamera2.encoders import Quality, _hw_encoder_available
 from picamera2.outputs import FileOutput
 
 from spyglass import WEBRTC_ENABLED, camera, logger
@@ -81,6 +81,8 @@ class CSI(camera.Camera):
         use_sw_encoding=False,
         mjpeg_linger_seconds=-1,
         webrtc_linger_seconds=5,
+        mjpg_quality: Quality | None = None,
+        h264_quality: Quality | None = None,
     ):
         if _hw_encoder_available and not use_sw_encoding:
             from picamera2.encoders import MJPEGEncoder
@@ -101,6 +103,7 @@ class CSI(camera.Camera):
             FileOutput(output),
             session=session,
             linger_seconds=mjpeg_linger_seconds,
+            quality=mjpg_quality,
         )
         StreamingHandler.mjpeg_encoder = mjpeg_encoder
         if WEBRTC_ENABLED:
@@ -112,6 +115,7 @@ class CSI(camera.Camera):
                 self.media_track,
                 session=session,
                 linger_seconds=webrtc_linger_seconds,
+                quality=h264_quality,
             )
             StreamingHandler.h264_encoder = h264_encoder
         else:

--- a/spyglass/camera/lazy_encoder.py
+++ b/spyglass/camera/lazy_encoder.py
@@ -23,6 +23,8 @@ LazyEncoder supports a ``linger_seconds`` parameter:
 
 import threading
 
+from picamera2.encoders import Quality
+
 
 class CameraSession:
     def __init__(self, picam2):
@@ -58,6 +60,7 @@ class LazyEncoder:
         output,
         session=None,
         linger_seconds=0,
+        quality: Quality | None = None,
     ):
         """
         :param picam2: the Picamera2 instance to start/stop the encoder on.
@@ -81,6 +84,7 @@ class LazyEncoder:
         self._lock = threading.Lock()
         self._stop_timer = None
         self._stop_token = 0
+        self._quality: Quality = quality
 
     def acquire(self):
         with self._lock:
@@ -94,7 +98,9 @@ class LazyEncoder:
                     self._session.acquire()
                     session_acquired = True
                 self._encoder = self._encoder_factory()
-                self._picam2.start_encoder(self._encoder, self._output)
+                self._picam2.start_encoder(
+                    self._encoder, self._output, quality=self._quality
+                )
             except Exception:
                 self._refs -= 1
                 self._encoder = None

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -1,6 +1,6 @@
 from picamera2.encoders import Quality
 
-from spyglass import camera
+from spyglass import camera, logger
 from spyglass.camera.camera import ServerConfig
 from spyglass.server.http_server import StreamingHandler
 
@@ -18,6 +18,9 @@ class USB(camera.Camera):
         def get_frame(inner_self):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer
             return self.picam2.capture_buffer()
+
+        if mjpg_quality is not None or h264_quality is not None:
+            logger.warning("Setting quality is not supported for USB cameras!")
 
         self.picam2.start()
 

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -1,3 +1,5 @@
+from picamera2.encoders import Quality
+
 from spyglass import camera
 from spyglass.camera.camera import ServerConfig
 from spyglass.server.http_server import StreamingHandler
@@ -10,6 +12,8 @@ class USB(camera.Camera):
         use_sw_encoding=False,
         mjpeg_linger_seconds=-1,
         webrtc_linger_seconds=5,
+        mjpg_quality: Quality | None = None,
+        h264_quality: Quality | None = None,
     ):
         def get_frame(inner_self):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -8,6 +8,7 @@ import re
 import sys
 
 import libcamera
+from picamera2.encoders import Quality
 
 from spyglass import WEBRTC_ENABLED, camera_options, logger, set_webrtc_enabled
 from spyglass.__version__ import __version__
@@ -107,6 +108,8 @@ def main(args=None):
             use_sw_encoding,
             parsed_args.mjpeg_linger_seconds,
             parsed_args.webrtc_linger_seconds,
+            parsed_args.mjpg_quality,
+            parsed_args.h264_quality,
         )
     finally:
         cam.stop()
@@ -162,6 +165,13 @@ def split_resolution(res):
     w = int(parts[0])
     h = int(parts[1])
     return w, h
+
+
+def parse_quality(quality):
+    try:
+        return Quality[quality.upper()]
+    except:
+        raise argparse.ArgumentTypeError(f"Invalid quality choice: {quality}")
 
 
 # endregion args parsers
@@ -391,6 +401,20 @@ def get_parser():
         "peer disconnects; a fresh connection within the window cancels "
         "the stop. Bridges brief reconnects without paying cold-start "
         "latency on each one.",
+    )
+    parser.add_argument(
+        "--mjpg-quality",
+        type=parse_quality,
+        choices=list(Quality),
+        default=None,
+        help="Sets the quality for the MJPG stream. Higher quality means less artifacts but higher CPU usage.",
+    )
+    parser.add_argument(
+        "--h264-quality",
+        type=parse_quality,
+        choices=list(Quality),
+        default=None,
+        help="Sets the quality for the WebRTC stream. Higher quality means less artifacts but higher CPU usage.",
     )
     camera_group = parser.add_mutually_exclusive_group()
     camera_group.add_argument(

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -407,14 +407,14 @@ def get_parser():
         type=parse_quality,
         choices=list(Quality),
         default=None,
-        help="Sets the quality for the MJPG stream. Higher quality means less artifacts but higher CPU usage.",
+        help="Sets the quality for the MJPG stream. Higher quality means less artifacts but higher CPU usage and network bandwidth.",
     )
     parser.add_argument(
         "--h264-quality",
         type=parse_quality,
         choices=list(Quality),
         default=None,
-        help="Sets the quality for the WebRTC stream. Higher quality means less artifacts but higher CPU usage.",
+        help="Sets the quality for the WebRTC stream. Higher quality means less artifacts but higher CPU usage and network bandwidth.",
     )
     camera_group = parser.add_mutually_exclusive_group()
     camera_group.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ DEFAULT_TUNING_FILTER_DIR = None
 DEFAULT_CAMERA_NUM = 0
 DEFAULT_MJPEG_LINGER_SECONDS = -1
 DEFAULT_WEBRTC_LINGER_SECONDS = 5
+DEFAULT_QUALITY = None
 
 
 mock_libcamera = MagicMock()
@@ -213,7 +214,12 @@ def test_run_server_with_configuration_from_arguments(mock_init_camera):
         "1.2.3.4", 1234, "streaming-url", "snapshot-url", "webrtc-url", 1
     )
     cam_instance.start_and_run_server.assert_called_once_with(
-        config, True, DEFAULT_MJPEG_LINGER_SECONDS, DEFAULT_WEBRTC_LINGER_SECONDS
+        config,
+        True,
+        DEFAULT_MJPEG_LINGER_SECONDS,
+        DEFAULT_WEBRTC_LINGER_SECONDS,
+        DEFAULT_QUALITY,
+        DEFAULT_QUALITY,
     )
 
 
@@ -256,5 +262,10 @@ def test_run_server_with_orientation(mock_init_camera, input_value, expected_out
         "1.2.3.4", 1234, "streaming-url", "snapshot-url", "webrtc-url", expected_output
     )
     cam_instance.start_and_run_server.assert_called_once_with(
-        config, True, DEFAULT_MJPEG_LINGER_SECONDS, DEFAULT_WEBRTC_LINGER_SECONDS
+        config,
+        True,
+        DEFAULT_MJPEG_LINGER_SECONDS,
+        DEFAULT_WEBRTC_LINGER_SECONDS,
+        DEFAULT_QUALITY,
+        DEFAULT_QUALITY,
     )

--- a/tests/test_lazy_encoder.py
+++ b/tests/test_lazy_encoder.py
@@ -28,7 +28,9 @@ def test_first_acquire_starts_session_then_encoder():
     lazy.acquire()
 
     picam2.start.assert_called_once_with()
-    picam2.start_encoder.assert_called_once_with(factory.return_value, output)
+    picam2.start_encoder.assert_called_once_with(
+        factory.return_value, output, quality=None
+    )
 
 
 def test_extra_acquires_share_encoder_and_session():


### PR DESCRIPTION
Adding adjustable quality. This changes the bitrate of the encoder and therefore the stream.
Default is `None` resulting in a fallback to the encoder default. The encoder default is `Quality.Medium` as of now, as you can see in the encoders source code:
https://github.com/raspberrypi/picamera2/blob/3e6dff099d3982c8fbdb25f7cbe2e4c17bac34f7/picamera2/encoders/h264_encoder.py#L110
https://github.com/raspberrypi/picamera2/blob/3e6dff099d3982c8fbdb25f7cbe2e4c17bac34f7/picamera2/encoders/jpeg_encoder.py#L62
https://github.com/raspberrypi/picamera2/blob/3e6dff099d3982c8fbdb25f7cbe2e4c17bac34f7/picamera2/encoders/mjpeg_encoder.py#L30