### PR TITLE
fix: log missing usb camera functions

### DIFF
--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -19,6 +19,10 @@ class USB(camera.Camera):
             # TODO: Cuts framerate in 1/n with n streams open, add some kind of buffer
             return self.picam2.capture_buffer()
 
+        if use_sw_encoding:
+            logger.warning("Using software encoding is not supported for USB cameras!")
+        if mjpeg_linger_seconds != -1 or webrtc_linger_seconds != 5:
+            logger.warning("Using linger sevonds is not supported for USB cameras!")
         if mjpg_quality is not None or h264_quality is not None:
             logger.warning("Setting quality is not supported for USB cameras!")
 

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -22,7 +22,7 @@ class USB(camera.Camera):
         if use_sw_encoding:
             logger.warning("Using software encoding is not supported for USB cameras!")
         if mjpeg_linger_seconds != -1 or webrtc_linger_seconds != 5:
-            logger.warning("Using linger sevonds is not supported for USB cameras!")
+            logger.warning("Using linger seconds is not supported for USB cameras!")
         if mjpg_quality is not None or h264_quality is not None:
             logger.warning("Setting quality is not supported for USB cameras!")
 

--- a/spyglass/camera/usb.py
+++ b/spyglass/camera/usb.py
@@ -20,11 +20,17 @@ class USB(camera.Camera):
             return self.picam2.capture_buffer()
 
         if use_sw_encoding:
-            logger.warning("Using software encoding is not supported for USB cameras!")
+            logger.warning(
+                "Using software encoding is not supported for USB cameras and will be ignored!"
+            )
         if mjpeg_linger_seconds != -1 or webrtc_linger_seconds != 5:
-            logger.warning("Using linger seconds is not supported for USB cameras!")
+            logger.warning(
+                "Using linger seconds is not supported for USB cameras and will be ignored!"
+            )
         if mjpg_quality is not None or h264_quality is not None:
-            logger.warning("Setting quality is not supported for USB cameras!")
+            logger.warning(
+                "Setting quality is not supported for USB cameras and will be ignored!"
+            )
 
         self.picam2.start()
 


### PR DESCRIPTION
USB cameras are quite limited in the functions spyglass supports. This PR logs a warning, if the user sets one of these function manually.