### PR TITLE
fix: fix resolution parsing with upper x

### DIFF
--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -161,7 +161,7 @@ def parse_autofocus_speed(arg_value: str) -> libcamera.controls.AfSpeedEnum:
 
 
 def split_resolution(res: str) -> tuple[int, int]:
-    parts = res.split("x")
+    parts = res.lower().split("x")
     w = int(parts[0])
     h = int(parts[1])
     return w, h


### PR DESCRIPTION
If you have set your resolution with an upper x like `1920X1080` instead of a lower one like `1920x1080` you end up with a crash. This PR makes sure to lower the resolution string before parsing.