### PR TITLE
chore: change flake8 to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,17 @@ bump_map = {"break" = "MAJOR", ".*!" = "MAJOR", "feat" = "MINOR", "fix" = "PATCH
 commit_parser = "^(?P<change_type>break|feat|fix|chore\\(deps\\))(!)?:\\s(?P<message>.*)?"
 change_type_map = {"feat" = "Feat", "fix" = "Fix", "chore(deps)" = "Dependency Update"}
 
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+extend-select = ["C90", "I", "UP"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+"typings/**/*.pyi" = ["F403", "F405"]
 
 [tool.basedpyright]
 pythonVersion = "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = E203
-exclude = .git,__pycache__,build,dist,.venv
-max-complexity = 10


### PR DESCRIPTION
This PR adds a ruff config, deprecating the `tox.ini` for `flake8`.
- `C90` adds mccabe and add complexity 10
- `I` adds sorting for imports
- `UP` adds automatic upgrading of old syntax to the minimum supported python version
- Ignoring `F403` and `F405` for `typings/**/*.pyi` to support `*` imports in the autogenerated stubs