### PR TITLE
ci: refactor release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
+        uses: commitizen-tools/commitizen-action@0.27.1
         id: bump
         with:
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           github_token: ${{ secrets.PAT }}
           changelog_increment_filename: release_body.md
+          branch: 'develop'
 
       - name: Upload Release Body
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 jobs:
-  push_to_main:
+  prepare_release:
     name: FF Merge and Bump version
     runs-on: ubuntu-latest
     outputs:
@@ -16,31 +16,15 @@ jobs:
       - name: Check out
         uses: actions/checkout@v7
         with:
+          ref: 'develop'
           fetch-depth: 0
-          ref: 'main'
-
-      - name: Fast Forward Merge To Main
-        uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
-        with:
-          branchtomerge: origin/develop
-          branch: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         id: bump
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
           changelog_increment_filename: release_body.md
-
-      - name: Fast Forward Merge To Develop
-        uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
-        with:
-          branchtomerge: main
-          branch: develop
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Upload Release Body
         uses: actions/upload-artifact@v7
@@ -53,11 +37,11 @@ jobs:
     needs: push_to_main
     uses: ./.github/workflows/build.yml
     with:
-      branch: 'main'
+      branch: 'develop'
 
   release:
     name: Create Release
-    needs: [push_to_main, build]
+    needs: [prepare_release, build]
     runs-on: ubuntu-latest
     steps:
       - name: Download all Artifacts
@@ -81,3 +65,22 @@ jobs:
           files: ./dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  push_to_main:
+    needs: [push_to_main, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          ref: 'main'
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      - name: Fast-forward merge from develop
+        shell: bash
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git merge --ff-only origin/develop
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           branchtomerge: main
           branch: develop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Upload Release Body
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
   build:
     name: Build wheel and .deb
-    needs: push_to_main
+    needs: prepare_release
     uses: ./.github/workflows/build.yml
     with:
       branch: 'develop'
@@ -61,13 +61,13 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           body_path: release_body.md
-          tag_name: v${{ needs.push_to_main.outputs.version }}
+          tag_name: v${{ needs.prepare_release.outputs.version }}
           files: ./dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   push_to_main:
-    needs: [push_to_main, build]
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master


### PR DESCRIPTION
This PR refactors the release workflow.

Old workflow:
FF Develop to Main ==> Commitizen version bump ==> FF Main to Develop ==> Build ==> Release

New workflow:
Commitizen version bump ==> Build ==> Release ==> FF Develop to Main
